### PR TITLE
optz: don't store moves

### DIFF
--- a/Rudim/Board/BoardState.Saved.cs
+++ b/Rudim/Board/BoardState.Saved.cs
@@ -10,7 +10,6 @@ namespace Rudim.Board
         private class SavedState
         {
             public Piece CapturedPiece { get; set; }
-            public List<Move> SavedMoves { get; set; }
             public Square EnPassantSquare { get; set; }
             public Castle CastlingRights { get; internal set; }
         }
@@ -32,7 +31,6 @@ namespace Rudim.Board
         {
             SavedStates.Push(new SavedState
             {
-                SavedMoves = Moves,
                 CapturedPiece = capturedPiece,
                 EnPassantSquare = enPassant,
                 CastlingRights = originalCastlingRights
@@ -42,7 +40,6 @@ namespace Rudim.Board
         private SavedState RestoreState()
         {
             var savedState = SavedStates.Pop();
-            Moves = savedState.SavedMoves;
             return savedState;
         }
 

--- a/Rudim/Search/Negamax.cs
+++ b/Rudim/Search/Negamax.cs
@@ -30,11 +30,10 @@ namespace Rudim.Search
             MoveOrdering.SortMoves(boardState);
 
             var numberOfLegalMoves = 0;
-            for (var i = 0; i < boardState.Moves.Count; ++i)
+            foreach (var move in boardState.Moves)
             {
                 if (cancellationToken.IsCancellationRequested)
                     break;
-                var move = boardState.Moves[i];
                 boardState.MakeMove(move);
                 if (boardState.IsInCheck(boardState.SideToMove.Other()))
                 {
@@ -54,7 +53,7 @@ namespace Rudim.Search
                 if (score > alpha)
                 {
                     alpha = score;
-                    bestEvaluation = boardState.Moves[i];
+                    bestEvaluation = move;
                 }
             }
 


### PR DESCRIPTION
extra overhead - the only thing that was directly using this was a for loop, converted it into a foreach loop