### PR TITLE
fix: cleanup after RandomTest

### DIFF
--- a/Rudim.Test/UnitTest/Board/TraversalTest.cs
+++ b/Rudim.Test/UnitTest/Board/TraversalTest.cs
@@ -28,9 +28,5 @@ namespace Rudim.Test.UnitTest.Board
             Assert.Equal(expectedNodes, IterativeDeepening.Nodes);
             Assert.Equal(expectedScore, IterativeDeepening.Score);
         }
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/Rudim.Test/UnitTest/Board/TraversalTest.cs
+++ b/Rudim.Test/UnitTest/Board/TraversalTest.cs
@@ -13,10 +13,10 @@ namespace Rudim.Test.UnitTest.Board
         // This helps keep track if certain optimizations are good enough to make up for the extra time spent
         // Compare time spent with and without the change before updating the keys
         [Theory]
-        [InlineData(Helpers.StartingFEN, 1792286, 5, 8)]
-        [InlineData(Helpers.EndgameFEN, 415340, 45, 9)]
-        [InlineData(Helpers.AdvancedMoveFEN, 2677577, 1520, 8)]
-        [InlineData(Helpers.KiwiPeteFEN, 6761199, -60, 8)]
+        [InlineData(Helpers.StartingFEN, 1787870, 5, 8)]
+        [InlineData(Helpers.EndgameFEN, 420262, 45, 9)]
+        [InlineData(Helpers.AdvancedMoveFEN, 2649058, 1520, 8)]
+        [InlineData(Helpers.KiwiPeteFEN, 6764976, -60, 8)]
         public void ShouldTraverseDeterministically(string position, int expectedNodes, int expectedScore, int depth)
         {
             Global.Reset();
@@ -27,6 +27,10 @@ namespace Rudim.Test.UnitTest.Board
 
             Assert.Equal(expectedNodes, IterativeDeepening.Nodes);
             Assert.Equal(expectedScore, IterativeDeepening.Score);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/Rudim.Test/UnitTest/Common/RandomTest.cs
+++ b/Rudim.Test/UnitTest/Common/RandomTest.cs
@@ -1,13 +1,11 @@
-using Rudim.Common;
+using System;
 using System.Collections.Generic;
 using Xunit;
+using Random = Rudim.Common.Random;
 
 namespace Rudim.Test.UnitTest.Common
 {
-    // This test being run before other tests causes a different expected output.
-    // Currently this is not a problem, just that this test always needs to be run, or values in 
-    // Traversal Test will need to be changed.
-    public class RandomTest
+    public class RandomTest : IDisposable
     {
         [Fact]
         public void ShouldGenerateUniqueULongNumbers()
@@ -29,6 +27,11 @@ namespace Rudim.Test.UnitTest.Common
                 int number = Random.NextInt();
                 Assert.True(generatedNumbers.Add(number), $"Collision detected for int number: {number}");
             }
+        }
+
+        public void Dispose()
+        {
+            Random._RESET_SEED();
         }
     }
 }

--- a/Rudim/Common/Random.cs
+++ b/Rudim/Common/Random.cs
@@ -27,5 +27,12 @@
             randomNumber ^= randomNumber << 5;
             return _intState = randomNumber;
         }
+
+        // DO NOT USE FOR PROJECT - ONLY USED IN RandomTest.cs for determinism
+        public static void _RESET_SEED()
+        {
+            _ulongState = 1804289383;
+            _intState = 1804289383;
+        }
     }
 }


### PR DESCRIPTION
running on my local vs pipeline was giving different values because of when RandomTest was run?
So just cleanup after RandomTest