### PR TITLE
eval: optimize & use Rofchade values

### DIFF
--- a/Rudim.Test/UnitTest/Board/PieceSquareTableEvaluationTest.cs
+++ b/Rudim.Test/UnitTest/Board/PieceSquareTableEvaluationTest.cs
@@ -5,7 +5,7 @@ using Helpers = Rudim.Common.Helpers;
 
 namespace Rudim.Test.UnitTest.Board
 {
-    public class SimpleEvaluationTest
+    public class PieceSquareTableEvaluationTest
     {
         [Theory]
         [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)] // White
@@ -18,7 +18,7 @@ namespace Rudim.Test.UnitTest.Board
         {
             BoardState boardState = BoardState.ParseFEN(fen);
 
-            int actualScore = SimpleEvaluation.Evaluate(boardState);
+            int actualScore = PieceSquareTableEvaluation.Evaluate(boardState);
 
             Assert.Equal(expectedScore, actualScore);
         }

--- a/Rudim.Test/UnitTest/Board/PieceSquareTableEvaluationTest.cs
+++ b/Rudim.Test/UnitTest/Board/PieceSquareTableEvaluationTest.cs
@@ -12,7 +12,7 @@ namespace Rudim.Test.UnitTest.Board
         [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1", 0)] // Black
         [InlineData(Helpers.EndgameFEN, 37)]
         [InlineData(Helpers.KiwiPeteFEN, 56)]
-        [InlineData(Helpers.AdvancedMoveFEN, 516)]
+        [InlineData(Helpers.AdvancedMoveFEN, 495)]
         
         public void ShouldReturnConsistentScoreForGivenPosition(string fen, int expectedScore)
         {

--- a/Rudim.Test/UnitTest/Board/SimpleEvaluationTest.cs
+++ b/Rudim.Test/UnitTest/Board/SimpleEvaluationTest.cs
@@ -1,0 +1,22 @@
+using Rudim.Board;
+using Xunit;
+
+namespace Rudim.Test.UnitTest.Board
+{
+    public class SimpleEvaluationTest
+    {
+        [Theory]
+        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)]
+        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1", 0)]
+        [InlineData("r4r2/pb4kp/1p4p1/1P6/2P1pRp1/P3B3/7P/5RK1 w - - 0 29", -200)]
+        
+        public void ShouldReturnConsistentScoreForGivenPosition(string fen, int expectedScore)
+        {
+            BoardState boardState = BoardState.ParseFEN(fen);
+
+            int actualScore = SimpleEvaluation.Evaluate(boardState);
+
+            Assert.Equal(expectedScore, actualScore);
+        }
+    }
+}

--- a/Rudim.Test/UnitTest/Board/SimpleEvaluationTest.cs
+++ b/Rudim.Test/UnitTest/Board/SimpleEvaluationTest.cs
@@ -1,14 +1,18 @@
 using Rudim.Board;
+using Rudim.Test.Util;
 using Xunit;
+using Helpers = Rudim.Common.Helpers;
 
 namespace Rudim.Test.UnitTest.Board
 {
     public class SimpleEvaluationTest
     {
         [Theory]
-        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)]
-        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1", 0)]
-        [InlineData("r4r2/pb4kp/1p4p1/1P6/2P1pRp1/P3B3/7P/5RK1 w - - 0 29", -200)]
+        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)] // White
+        [InlineData("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1", 0)] // Black
+        [InlineData(Helpers.EndgameFEN, 37)]
+        [InlineData(Helpers.KiwiPeteFEN, 56)]
+        [InlineData(Helpers.AdvancedMoveFEN, 516)]
         
         public void ShouldReturnConsistentScoreForGivenPosition(string fen, int expectedScore)
         {

--- a/Rudim.Test/UnitTest/Board/TacticsTest.cs
+++ b/Rudim.Test/UnitTest/Board/TacticsTest.cs
@@ -1,0 +1,30 @@
+using Rudim.Board;
+using Rudim.Common;
+using System.Threading;
+using Xunit;
+using Helpers = Rudim.Test.Util.Helpers;
+
+namespace Rudim.Test.UnitTest.Board
+{
+    [Collection("StateRace")]
+    public class TacticsTest
+    {
+        [Theory]
+        [InlineData("r4r2/pb4kp/1p4p1/1P6/2P1pRp1/P3B3/7P/5RK1 w - - 0 29", "f4f8")]
+        public void ShouldNotMissBestMoveForTactic(string fen, string moveLan)
+        {
+            Global.Reset();
+            BoardState boardState = BoardState.ParseFEN(fen);
+            
+            CancellationTokenSource cancellationToken = new(5000);
+            bool debugMode = false;
+            Move bestMove = boardState.FindBestMove(25, cancellationToken.Token, ref debugMode);
+
+            Move expectedMove = Move.ParseLongAlgebraic(moveLan);
+            boardState.GenerateMoves();
+            expectedMove = Helpers.FindMoveFromMoveList(boardState, expectedMove);
+            
+            Assert.Equal(expectedMove, bestMove);
+        }
+    }
+}

--- a/Rudim.Test/UnitTest/Board/TraversalTest.cs
+++ b/Rudim.Test/UnitTest/Board/TraversalTest.cs
@@ -13,10 +13,10 @@ namespace Rudim.Test.UnitTest.Board
         // This helps keep track if certain optimizations are good enough to make up for the extra time spent
         // Compare time spent with and without the change before updating the keys
         [Theory]
-        [InlineData(Helpers.StartingFEN, 1787870, 5, 8)]
-        [InlineData(Helpers.EndgameFEN, 420262, 45, 9)]
-        [InlineData(Helpers.AdvancedMoveFEN, 2649058, 1520, 8)]
-        [InlineData(Helpers.KiwiPeteFEN, 6764976, -60, 8)]
+        [InlineData(Helpers.StartingFEN, 2564147, 5, 8)]
+        [InlineData(Helpers.EndgameFEN, 343666, 45, 9)]
+        [InlineData(Helpers.AdvancedMoveFEN, 2898803, 1520, 8)]
+        [InlineData(Helpers.KiwiPeteFEN, 10316524, -60, 8)]
         public void ShouldTraverseDeterministically(string position, int expectedNodes, int expectedScore, int depth)
         {
             Global.Reset();

--- a/Rudim.Test/UnitTest/Board/TraversalTest.cs
+++ b/Rudim.Test/UnitTest/Board/TraversalTest.cs
@@ -13,10 +13,10 @@ namespace Rudim.Test.UnitTest.Board
         // This helps keep track if certain optimizations are good enough to make up for the extra time spent
         // Compare time spent with and without the change before updating the keys
         [Theory]
-        [InlineData(Helpers.StartingFEN, 2564147, 5, 8)]
-        [InlineData(Helpers.EndgameFEN, 343666, 45, 9)]
-        [InlineData(Helpers.AdvancedMoveFEN, 2898803, 1520, 8)]
-        [InlineData(Helpers.KiwiPeteFEN, 10316524, -60, 8)]
+        [InlineData(Helpers.StartingFEN, 2574755, 12, 8)]
+        [InlineData(Helpers.EndgameFEN, 344654, 39, 9)]
+        [InlineData(Helpers.AdvancedMoveFEN, 3035484, 1707, 8)]
+        [InlineData(Helpers.KiwiPeteFEN, 7075274, -116, 8)]
         public void ShouldTraverseDeterministically(string position, int expectedNodes, int expectedScore, int depth)
         {
             Global.Reset();

--- a/Rudim/Board/PieceSquareTableEvaluation.cs
+++ b/Rudim/Board/PieceSquareTableEvaluation.cs
@@ -49,10 +49,10 @@ namespace Rudim.Board
 
         private static int MirrorSquare(int square)
         {
-            int row = square >> 3;
-            int col = square - ((square >> 3) << 3);
+            int row = square >> 3; // Square / 8
+            int col = square & (8 - 1); // Square % 8
 
-            return ((7 - row) << 3) + col;
+            return ((7 - row) << 3) + col; // (7 - Row) * 8 + col
         }
 
         static PieceSquareTableEvaluation()

--- a/Rudim/Board/PieceSquareTableEvaluation.cs
+++ b/Rudim/Board/PieceSquareTableEvaluation.cs
@@ -57,7 +57,8 @@ namespace Rudim.Board
 
         static PieceSquareTableEvaluation()
         {
-            int[] pieceValues = [100, 320, 330, 500, 900, 20000];
+            int[] midGamePieceValues = [82, 337, 365, 477, 1025,  0];
+            int[] endGamePieceValues = [94, 281, 297, 512,  936,  0];
 
             // Values borrowed from Rofchade 
             // http://www.talkchess.com/forum3/viewtopic.php?f=2&t=68311&start=19
@@ -205,8 +206,8 @@ namespace Rudim.Board
             {
                 for (int square = 0; square < Constants.Squares; ++square)
                 {
-                    MidGamePositions[piece, square] += pieceValues[piece];
-                    EndGamePositions[piece, square] += pieceValues[piece];
+                    MidGamePositions[piece, square] += midGamePieceValues[piece];
+                    EndGamePositions[piece, square] += endGamePieceValues[piece];
                 }
             }
         }

--- a/Rudim/Board/PieceSquareTableEvaluation.cs
+++ b/Rudim/Board/PieceSquareTableEvaluation.cs
@@ -2,7 +2,7 @@
 
 namespace Rudim.Board
 {
-    public static class SimpleEvaluation
+    public static class PieceSquareTableEvaluation
     {
         private static readonly int[,] MidGamePositions;
         private static readonly int[,] EndGamePositions;
@@ -55,7 +55,7 @@ namespace Rudim.Board
             return ((7 - row) << 3) + col;
         }
 
-        static SimpleEvaluation()
+        static PieceSquareTableEvaluation()
         {
             int[] pieceValues = [100, 320, 330, 500, 900, 20000];
 

--- a/Rudim/Board/SimpleEvaluation.cs
+++ b/Rudim/Board/SimpleEvaluation.cs
@@ -3,12 +3,11 @@ using System.Numerics;
 
 namespace Rudim.Board
 {
-    internal static class SimpleEvaluation
+    public static class SimpleEvaluation
     {
         private static readonly int[] PieceValues;
-        private static readonly int[,] PositionValues;
-        private static readonly int[] MidGameKingValues;
-        private static readonly int[] EndGameKingValues;
+        private static readonly int[,] MidGamePositions;
+        private static readonly int[,] EndGamePositions;
 
 
         public static int Evaluate(BoardState boardState)
@@ -28,24 +27,14 @@ namespace Rudim.Board
             int endGamePhase = GamePhase.TotalPhase - midGamePhase;
             for (int piece = 0; piece < Constants.Pieces; ++piece)
             {
-                Bitboard whiteBoard = new Bitboard(boardState.Pieces[(int)Side.White, piece].Board);
-                Bitboard blackBoard = new Bitboard(boardState.Pieces[(int)Side.Black, piece].Board);
-
-                if (piece == Constants.Pieces - 1)
-                {
-                    int whiteKing = whiteBoard.GetLsb();
-                    int blackKing = MirrorSquare(blackBoard.GetLsb());
-
-                    positionalScore += (int)(((MidGameKingValues[whiteKing] * midGamePhase) + (EndGameKingValues[whiteKing] * endGamePhase)) * GamePhase.PhaseFactor);
-                    positionalScore -= (int)(((MidGameKingValues[blackKing] * midGamePhase) + (EndGameKingValues[blackKing] * endGamePhase)) * GamePhase.PhaseFactor);
-                    continue;
-                }
+                Bitboard whiteBoard = new(boardState.Pieces[(int)Side.White, piece].Board);
+                Bitboard blackBoard = new(boardState.Pieces[(int)Side.Black, piece].Board);
 
                 while (whiteBoard.Board > 0)
                 {
                     int square = whiteBoard.GetLsb();
                     whiteBoard.ClearBit(square);
-                    positionalScore += PositionValues[piece, square];
+                    positionalScore += (int)((( MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase)) * GamePhase.PhaseFactor);
                 }
 
                 while (blackBoard.Board > 0)
@@ -53,7 +42,7 @@ namespace Rudim.Board
                     int square = blackBoard.GetLsb();
                     blackBoard.ClearBit(square);
                     square = MirrorSquare(square);
-                    positionalScore -= PositionValues[piece, square];
+                    positionalScore -= (int)((( MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase)) * GamePhase.PhaseFactor);
                 }
             }
             return positionalScore;
@@ -62,9 +51,9 @@ namespace Rudim.Board
         private static int MirrorSquare(int square)
         {
             int row = square >> 3;
-            int col = square - (square >> 3) * 8;
+            int col = square - ((square >> 3) << 3);
 
-            return (7 - row) * 8 + col;
+            return ((7 - row) << 3) + col;
         }
 
         private static int ScoreMaterial(BoardState boardState)
@@ -81,70 +70,157 @@ namespace Rudim.Board
         static SimpleEvaluation()
         {
             PieceValues = [100, 320, 330, 500, 900, 20000];
-            PositionValues = new[,]
-            { { 0,  0,  0,  0,  0,  0,  0,  0,
-                50, 50, 50, 50, 50, 50, 50, 50,
-                10, 10, 20, 30, 30, 20, 10, 10,
-                5,  5, 10, 25, 25, 10,  5,  5,
-                0,  0,  0, 20, 20,  0,  0,  0,
-                5, -5,-10,  0,  0,-10, -5,  5,
-                5, 10, 10,-20,-20, 10, 10,  5,
-                0,  0,  0,  0,  0,  0,  0,  0},
-               { -50,-40,-30,-30,-30,-30,-40,-50,
-                 -40,-20,  0,  0,  0,  0,-20,-40,
-                 -30,  0, 10, 15, 15, 10,  0,-30,
-                 -30,  5, 15, 20, 20, 15,  5,-30,
-                 -30,  0, 15, 20, 20, 15,  0,-30,
-                 -30,  5, 10, 15, 15, 10,  5,-30,
-                 -40,-20,  0,  5,  5,  0,-20,-40,
-                 -50,-40,-30,-30,-30,-30,-40,-50},
-               { -20,-10,-10,-10,-10,-10,-10,-20,
-                 -10,  0,  0,  0,  0,  0,  0,-10,
-                 -10,  0,  5, 10, 10,  5,  0,-10,
-                 -10,  5,  5, 10, 10,  5,  5,-10,
-                 -10,  0, 10, 10, 10, 10,  0,-10,
-                 -10, 10, 10, 10, 10, 10, 10,-10,
-                 -10,  5,  0,  0,  0,  0,  5,-10,
-                 -20,-10,-10,-10,-10,-10,-10,-20},
-               { 0,  0,  0,  0,  0,  0,  0,  0,
-                 5, 10, 10, 10, 10, 10, 10,  5,
-                 -5,  0,  0,  0,  0,  0,  0, -5,
-                 -5,  0,  0,  0,  0,  0,  0, -5,
-                 -5,  0,  0,  0,  0,  0,  0, -5,
-                 -5,  0,  0,  0,  0,  0,  0, -5,
-                 -5,  0,  0,  0,  0,  0,  0, -5,
-                 0,  0,  0,  5,  5,  0,  0,  0},
-               { -20,-10,-10, -5, -5,-10,-10,-20,
-                 -10,  0,  0,  0,  0,  0,  0,-10,
-                 -10,  0,  5,  5,  5,  5,  0,-10,
-                 -5,  0,  5,  5,  5,  5,  0, -5,
-                 0,  0,  5,  5,  5,  5,  0, -5,
-                 -10,  5,  5,  5,  5,  5,  0,-10,
-                 -10,  0,  5,  0,  0,  0,  0,-10,
-                 -20,-10,-10, -5, -5,-10,-10,-20}
+            
+            // Values borrowed from Rofchade 
+            // http://www.talkchess.com/forum3/viewtopic.php?f=2&t=68311&start=19
+            MidGamePositions = new[,]
+            { 
+                // Pawn
+                { 
+                0,   0,   0,   0,   0,   0,  0,   0,
+                98, 134,  61,  95,  68, 126, 34, -11,
+                -6,   7,  26,  31,  65,  56, 25, -20,
+                -14,  13,   6,  21,  23,  12, 17, -23,
+                -27,  -2,  -5,  12,  17,   6, 10, -25,
+                -26,  -4,  -4, -10,   3,   3, 33, -12,
+                -35,  -1, -20, -23, -15,  24, 38, -22,
+                0,   0,   0,   0,   0,   0,  0,   0
+                },
+                // Knight
+               { 
+                -167, -89, -34, -49,  61, -97, -15, -107,
+                -73, -41,  72,  36,  23,  62,   7,  -17,
+                -47,  60,  37,  65,  84, 129,  73,   44,
+                -9,  17,  19,  53,  37,  69,  18,   22,
+                -13,   4,  16,  13,  28,  19,  21,   -8,
+                -23,  -9,  12,  10,  19,  17,  25,  -16,
+                -29, -53, -12,  -3,  -1,  18, -14,  -19,
+                -105, -21, -58, -33, -17, -28, -19,  -23,
+               },
+               // Bishop
+               { 
+                -29,   4, -82, -37, -25, -42,   7,  -8,
+                -26,  16, -18, -13,  30,  59,  18, -47,
+                -16,  37,  43,  40,  35,  50,  37,  -2,
+                -4,   5,  19,  50,  37,  37,   7,  -2,
+                -6,  13,  13,  26,  34,  12,  10,   4,
+                0,  15,  15,  15,  14,  27,  18,  10,
+                4,  15,  16,   0,   7,  21,  33,   1,
+                -33,  -3, -14, -21, -13, -12, -39, -21,
+               },
+               // Rook
+               { 
+                32,  42,  32,  51, 63,  9,  31,  43,
+                27,  32,  58,  62, 80, 67,  26,  44,
+                -5,  19,  26,  36, 17, 45,  61,  16,
+                -24, -11,   7,  26, 24, 35,  -8, -20,
+                -36, -26, -12,  -1,  9, -7,   6, -23,
+                -45, -25, -16, -17,  3,  0,  -5, -33,
+                -44, -16, -20,  -9, -1, 11,  -6, -71,
+                -19, -13,   1,  17, 16,  7, -37, -26,
+               },
+               // Queen
+               { 
+                -28,   0,  29,  12,  59,  44,  43,  45,
+                -24, -39,  -5,   1, -16,  57,  28,  54,
+                -13, -17,   7,   8,  29,  56,  47,  57,
+                -27, -27, -16, -16,  -1,  17,  -2,   1,
+                -9, -26,  -9, -10,  -2,  -4,   3,  -3,
+                -14,   2, -11,  -2,  -5,   2,  14,   5,
+                -35,  -8,  11,   2,   8,  15,  -3,   1,
+                -1, -18,  -9,  10, -15, -25, -31, -50,
+               },
+               // King
+               {
+                -65,  23,  16, -15, -56, -34,   2,  13,
+                29,  -1, -20,  -7,  -8,  -4, -38, -29,
+                -9,  24,   2, -16, -20,   6,  22, -22,
+                -17, -20, -12, -27, -30, -25, -14, -36,
+                -49,  -1, -27, -39, -46, -44, -33, -51,
+                -14, -14, -22, -46, -44, -30, -15, -27,
+                1,   7,  -8, -64, -43, -16,   9,   8,
+                -15,  36,  12, -54,   8, -28,  24,  14,
+               }
             };
-            MidGameKingValues =
-            [
-                -30,-40,-40,-50,-50,-40,-40,-30,
-                -30,-40,-40,-50,-50,-40,-40,-30,
-                -30,-40,-40,-50,-50,-40,-40,-30,
-                -30,-40,-40,-50,-50,-40,-40,-30,
-                -20,-30,-30,-40,-40,-30,-30,-20,
-                -10,-20,-20,-20,-20,-20,-20,-10,
-                20, 20,  0,  0,  0,  0, 20, 20,
-                20, 30, 10,  0,  0, 10, 30, 20
-            ];
-            EndGameKingValues =
-            [
-                -50,-40,-30,-20,-20,-30,-40,-50,
-                -30,-20,-10,  0,  0,-10,-20,-30,
-                -30,-10, 20, 30, 30, 20,-10,-30,
-                -30,-10, 30, 40, 40, 30,-10,-30,
-                -30,-10, 30, 40, 40, 30,-10,-30,
-                -30,-10, 20, 30, 30, 20,-10,-30,
-                -30,-30,  0,  0,  0,  0,-30,-30,
-                -50,-30,-30,-30,-30,-30,-30,-50
-            ];
+            
+            EndGamePositions = new[,]
+            { 
+                // Pawn
+                { 
+                0,   0,   0,   0,   0,   0,   0,   0,
+                178, 173, 158, 134, 147, 132, 165, 187,
+                94, 100,  85,  67,  56,  53,  82,  84,
+                32,  24,  13,   5,  -2,   4,  17,  17,
+                13,   9,  -3,  -7,  -7,  -8,   3,  -1,
+                4,   7,  -6,   1,   0,  -5,  -1,  -8,
+                13,   8,   8,  10,  13,   0,   2,  -7,
+                0,   0,   0,   0,   0,   0,   0,   0,
+                },
+                // Knight
+               { 
+                -58, -38, -13, -28, -31, -27, -63, -99,
+                -25,  -8, -25,  -2,  -9, -25, -24, -52,
+                -24, -20,  10,   9,  -1,  -9, -19, -41,
+                -17,   3,  22,  22,  22,  11,   8, -18,
+                -18,  -6,  16,  25,  16,  17,   4, -18,
+                -23,  -3,  -1,  15,  10,  -3, -20, -22,
+                -42, -20, -10,  -5,  -2, -20, -23, -44,
+                -29, -51, -23, -15, -22, -18, -50, -64,
+               },
+               // Bishop
+               { 
+                -14, -21, -11,  -8, -7,  -9, -17, -24,
+                -8,  -4,   7, -12, -3, -13,  -4, -14,
+                2,  -8,   0,  -1, -2,   6,   0,   4,
+                -3,   9,  12,   9, 14,  10,   3,   2,
+                -6,   3,  13,  19,  7,  10,  -3,  -9,
+                -12,  -3,   8,  10, 13,   3,  -7, -15,
+                -14, -18,  -7,  -1,  4,  -9, -15, -27,
+                -23,  -9, -23,  -5, -9, -16,  -5, -17,
+               },
+               // Rook
+               { 
+                   13, 10, 18, 15, 12,  12,   8,   5,
+                   11, 13, 13, 11, -3,   3,   8,   3,
+                   7,  7,  7,  5,  4,  -3,  -5,  -3,
+                   4,  3, 13,  1,  2,   1,  -1,   2,
+                   3,  5,  8,  4, -5,  -6,  -8, -11,
+                   -4,  0, -5, -1, -7, -12,  -8, -16,
+                   -6, -6,  0,  2, -9,  -9, -11,  -3,
+                   -9,  2,  3, -1, -5, -13,   4, -20,
+               },
+               // Queen
+               { 
+                -9,  22,  22,  27,  27,  19,  10,  20,
+                -17,  20,  32,  41,  58,  25,  30,   0,
+                -20,   6,   9,  49,  47,  35,  19,   9,
+                3,  22,  24,  45,  57,  40,  57,  36,
+                -18,  28,  19,  47,  31,  34,  39,  23,
+                -16, -27,  15,   6,   9,  17,  10,   5,
+                -22, -23, -30, -16, -16, -23, -36, -32,
+                -33, -28, -22, -43,  -5, -32, -20, -41,
+               },
+               // King
+               {
+                -74, -35, -18, -18, -11,  15,   4, -17,
+                -12,  17,  14,  17,  17,  38,  23,  11,
+                10,  17,  23,  15,  20,  45,  44,  13,
+                -8,  22,  24,  27,  26,  33,  26,   3,
+                -18,  -4,  21,  24,  27,  23,   9, -11,
+                -19,  -3,  11,  21,  23,  16,   7,  -9,
+                -27, -11,   4,  13,  14,   4,  -5, -17,
+                -53, -34, -21, -11, -28, -14, -24, -43
+               }
+            };
+            
+            // for (int piece = 0; piece < Constants.Pieces; ++piece)
+            // {
+            //     for (int square = 0; square < Constants.Squares; ++square)
+            //     {
+            //         MidGamePositions[piece, square] += PieceValues[piece];
+            //         EndGamePositions[piece, square] += PieceValues[piece];
+            //     }
+            // }
         }
     }
 }

--- a/Rudim/Board/SimpleEvaluation.cs
+++ b/Rudim/Board/SimpleEvaluation.cs
@@ -1,11 +1,9 @@
 ﻿using Rudim.Common;
-using System.Numerics;
 
 namespace Rudim.Board
 {
     public static class SimpleEvaluation
     {
-        private static readonly int[] PieceValues;
         private static readonly int[,] MidGamePositions;
         private static readonly int[,] EndGamePositions;
 
@@ -14,7 +12,6 @@ namespace Rudim.Board
         {
             int score = 0;
 
-            score += ScoreMaterial(boardState);
             score += ScorePosition(boardState);
 
             return boardState.SideToMove == Side.White ? score : -score;
@@ -34,7 +31,7 @@ namespace Rudim.Board
                 {
                     int square = whiteBoard.GetLsb();
                     whiteBoard.ClearBit(square);
-                    positionalScore += (int)((( MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase)) * GamePhase.PhaseFactor);
+                    positionalScore += (MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase);
                 }
 
                 while (blackBoard.Board > 0)
@@ -42,9 +39,11 @@ namespace Rudim.Board
                     int square = blackBoard.GetLsb();
                     blackBoard.ClearBit(square);
                     square = MirrorSquare(square);
-                    positionalScore -= (int)((( MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase)) * GamePhase.PhaseFactor);
+                    positionalScore -=  (MidGamePositions[piece, square] * midGamePhase) + (EndGamePositions[piece, square] * endGamePhase);
                 }
             }
+
+            positionalScore = (int)(positionalScore * GamePhase.PhaseFactor);
             return positionalScore;
         }
 
@@ -56,21 +55,10 @@ namespace Rudim.Board
             return ((7 - row) << 3) + col;
         }
 
-        private static int ScoreMaterial(BoardState boardState)
-        {
-            int materialScore = 0;
-            for (int piece = 0; piece < Constants.Pieces; ++piece)
-            {
-                materialScore += PieceValues[piece] * BitOperations.PopCount(boardState.Pieces[(int)Side.White, piece].Board);
-                materialScore -= PieceValues[piece] * BitOperations.PopCount(boardState.Pieces[(int)Side.Black, piece].Board);
-            }
-            return materialScore;
-        }
-
         static SimpleEvaluation()
         {
-            PieceValues = [100, 320, 330, 500, 900, 20000];
-            
+            int[] pieceValues = [100, 320, 330, 500, 900, 20000];
+
             // Values borrowed from Rofchade 
             // http://www.talkchess.com/forum3/viewtopic.php?f=2&t=68311&start=19
             MidGamePositions = new[,]
@@ -213,14 +201,14 @@ namespace Rudim.Board
                }
             };
             
-            // for (int piece = 0; piece < Constants.Pieces; ++piece)
-            // {
-            //     for (int square = 0; square < Constants.Squares; ++square)
-            //     {
-            //         MidGamePositions[piece, square] += PieceValues[piece];
-            //         EndGamePositions[piece, square] += PieceValues[piece];
-            //     }
-            // }
+            for (int piece = 0; piece < Constants.Pieces; ++piece)
+            {
+                for (int square = 0; square < Constants.Squares; ++square)
+                {
+                    MidGamePositions[piece, square] += pieceValues[piece];
+                    EndGamePositions[piece, square] += pieceValues[piece];
+                }
+            }
         }
     }
 }

--- a/Rudim/Search/Quiescence.cs
+++ b/Rudim/Search/Quiescence.cs
@@ -14,7 +14,7 @@ namespace Rudim.Search
             if (boardState.IsDraw())
                 return 0;
 
-            int eval = SimpleEvaluation.Evaluate(boardState);
+            int eval = PieceSquareTableEvaluation.Evaluate(boardState);
 
             if (eval >= beta)
                 return beta;


### PR DESCRIPTION
- Taper all pieces, not just king
- Avoids extra PhaseFactor multiplications every time, does it at the end
- Use Rofchade values, previously using Simplified Values which aren't very strong. ref: https://www.chessprogramming.org/PeSTO%27s_Evaluation_Function
- Avoid extra looping to calculate material value - we are already adding each piece's postion, so just precompute the position tables `+= MaterialValue`
- Seeing some huge improvements with this