### PR TITLE
fix: zobrist bug with castling hashes

### DIFF
--- a/Rudim.Test/UnitTest/Board/TraversalTest.cs
+++ b/Rudim.Test/UnitTest/Board/TraversalTest.cs
@@ -13,10 +13,10 @@ namespace Rudim.Test.UnitTest.Board
         // This helps keep track if certain optimizations are good enough to make up for the extra time spent
         // Compare time spent with and without the change before updating the keys
         [Theory]
-        [InlineData(Helpers.StartingFEN, 581128, 8, 8)]
+        [InlineData(Helpers.StartingFEN, 580497, 8, 8)]
         [InlineData(Helpers.EndgameFEN, 126686, 40, 9)]
-        [InlineData(Helpers.AdvancedMoveFEN, 1272257, 1781, 8)]
-        [InlineData(Helpers.KiwiPeteFEN, 3071601, -49, 8)]
+        [InlineData(Helpers.AdvancedMoveFEN, 1277071, 1781, 8)]
+        [InlineData(Helpers.KiwiPeteFEN, 3080898, -49, 8)]
         public void ShouldTraverseDeterministically(string position, int expectedNodes, int expectedScore, int depth)
         {
             Global.Reset();

--- a/Rudim/Common/Zobrist.cs
+++ b/Rudim/Common/Zobrist.cs
@@ -22,10 +22,11 @@ namespace Rudim.Common
             ZobristTable[13, 0] = Random.NextULong(); // White to move
             ZobristTable[13, 1] = Random.NextULong(); // Black to move
 
-            ZobristTable[13, 2] = Random.NextULong();
-            ZobristTable[13, 3] = Random.NextULong();
-            ZobristTable[13, 4] = Random.NextULong();
-            ZobristTable[13, 5] = Random.NextULong();
+            // 16 possible castling states (4 bits)
+            for (int i = 2; i < 18; i++)
+            {
+                ZobristTable[13, i] = Random.NextULong();
+            }
         }
 
         public static ulong GetBoardHash(BoardState boardState)
@@ -53,7 +54,8 @@ namespace Rudim.Common
 
         public static ulong HashCastlingRights(BoardState boardState, ulong currentHash)
         {
-            currentHash ^= ZobristTable[13, (int)boardState.Castle];
+            // Offset by 2 to avoid collision with side-to-move keys (which use [13, 0] and [13, 1])
+            currentHash ^= ZobristTable[13, 2 + (int)boardState.Castle];
             return currentHash;
         }
 


### PR DESCRIPTION
castling hashes were not correct - it was always hashing to the same value and it was colliding with the sidetomove hash