### PR TITLE
refactor: use get() instead of Deref for LazyLock

### DIFF
--- a/src/bitboard/lookups.rs
+++ b/src/bitboard/lookups.rs
@@ -1,4 +1,4 @@
-use std::sync::{Once, OnceLock};
+use std::sync::LazyLock;
 
 use crate::bitboard::Bitboard;
 use crate::bitboard::attacks::{
@@ -11,97 +11,72 @@ use crate::common::constants::{MAX_BISHOP_MASK, MAX_ROOK_MASK, SQUARES};
 use crate::common::side::Side;
 use crate::common::square::Square;
 
-static BISHOP_MASK_BITS: OnceLock<[u32; SQUARES]> = OnceLock::new();
-static ROOK_MASK_BITS: OnceLock<[u32; SQUARES]> = OnceLock::new();
-static BISHOP_MASKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
-static ROOK_MASKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
-static PAWN_ATTACKS: OnceLock<[[u64; SQUARES]; 2]> = OnceLock::new();
-static KNIGHT_ATTACKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
-static KING_ATTACKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
-static BISHOP_ATTACKS: OnceLock<Vec<[u64; MAX_BISHOP_MASK]>> = OnceLock::new();
-static ROOK_ATTACKS: OnceLock<Vec<[u64; MAX_ROOK_MASK]>> = OnceLock::new();
-
-macro_rules! get_table {
-    ($lock:expr) => {
-        {
-            #[cfg(debug_assertions)]
-            {
-                if $lock.get().is_none() {
-                    crate::init();
-                }
-                $lock.get().unwrap()
-            }
-            #[cfg(not(debug_assertions))]
-            {
-                unsafe { $lock.get().unwrap_unchecked() }
-            }
-        }
-    };
-}
-
-#[inline(always)] fn bishop_mask_bits() -> &'static [u32; SQUARES] { get_table!(BISHOP_MASK_BITS) }
-#[inline(always)] fn rook_mask_bits() -> &'static [u32; SQUARES] { get_table!(ROOK_MASK_BITS) }
-#[inline(always)] fn bishop_masks() -> &'static [u64; SQUARES] { get_table!(BISHOP_MASKS) }
-#[inline(always)] fn rook_masks() -> &'static [u64; SQUARES] { get_table!(ROOK_MASKS) }
-#[inline(always)] pub fn pawn_attacks() -> &'static [[u64; SQUARES]; 2] { get_table!(PAWN_ATTACKS) }
-#[inline(always)] pub fn knight_attacks() -> &'static [u64; SQUARES] { get_table!(KNIGHT_ATTACKS) }
-#[inline(always)] pub fn king_attacks() -> &'static [u64; SQUARES] { get_table!(KING_ATTACKS) }
-#[inline(always)] fn bishop_attacks() -> &'static Vec<[u64; MAX_BISHOP_MASK]> { get_table!(BISHOP_ATTACKS) }
-#[inline(always)] fn rook_attacks() -> &'static Vec<[u64; MAX_ROOK_MASK]> { get_table!(ROOK_ATTACKS) }
-
-static INIT_ONCE: Once = Once::new();
-
-pub fn init() {
-    INIT_ONCE.call_once(|| {
-        let mut bishop_mask_bits_table = [0u32; SQUARES];
-    for (sq, entry) in bishop_mask_bits_table.iter_mut().enumerate() {
+static BISHOP_MASK_BITS: LazyLock<[u32; SQUARES]> = LazyLock::new(|| {
+    let mut bits = [0u32; SQUARES];
+    for (sq, entry) in bits.iter_mut().enumerate() {
         *entry = get_bishop_mask(Square::from(sq)).0.count_ones();
     }
-    BISHOP_MASK_BITS.set(bishop_mask_bits_table).unwrap();
+    bits
+});
 
-    let mut rook_mask_bits_table = [0u32; SQUARES];
-    for (sq, entry) in rook_mask_bits_table.iter_mut().enumerate() {
+static ROOK_MASK_BITS: LazyLock<[u32; SQUARES]> = LazyLock::new(|| {
+    let mut bits = [0u32; SQUARES];
+    for (sq, entry) in bits.iter_mut().enumerate() {
         *entry = get_rook_mask(Square::from(sq)).0.count_ones();
     }
-    ROOK_MASK_BITS.set(rook_mask_bits_table).unwrap();
+    bits
+});
 
-    let mut bishop_masks_table = [0u64; SQUARES];
-    for (sq, entry) in bishop_masks_table.iter_mut().enumerate() {
+static BISHOP_MASKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
+    let mut masks = [0u64; SQUARES];
+    for (sq, entry) in masks.iter_mut().enumerate() {
         *entry = get_bishop_mask(Square::from(sq)).0;
     }
-    BISHOP_MASKS.set(bishop_masks_table).unwrap();
+    masks
+});
 
-    let mut rook_masks_table = [0u64; SQUARES];
-    for (sq, entry) in rook_masks_table.iter_mut().enumerate() {
+static ROOK_MASKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
+    let mut masks = [0u64; SQUARES];
+    for (sq, entry) in masks.iter_mut().enumerate() {
         *entry = get_rook_mask(Square::from(sq)).0;
     }
-    ROOK_MASKS.set(rook_masks_table).unwrap();
+    masks
+});
 
-    let mut pawn_attacks_table = [[0u64; SQUARES]; 2];
-    for (sq, entry) in pawn_attacks_table[Side::White as usize].iter_mut().enumerate() {
+static PAWN_ATTACKS: LazyLock<[[u64; SQUARES]; 2]> = LazyLock::new(|| {
+    let mut table = [[0u64; SQUARES]; 2];
+    for (sq, entry) in table[Side::White as usize].iter_mut().enumerate() {
         *entry = get_pawn_attacks(Square::from(sq), Side::White).0;
     }
-    for (sq, entry) in pawn_attacks_table[Side::Black as usize].iter_mut().enumerate() {
+    for (sq, entry) in table[Side::Black as usize].iter_mut().enumerate() {
         *entry = get_pawn_attacks(Square::from(sq), Side::Black).0;
     }
-    PAWN_ATTACKS.set(pawn_attacks_table).unwrap();
+    table
+});
 
-    let mut knight_attacks_table = [0u64; SQUARES];
-    for (sq, entry) in knight_attacks_table.iter_mut().enumerate() {
+static KNIGHT_ATTACKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
+    let mut table = [0u64; SQUARES];
+    for (sq, entry) in table.iter_mut().enumerate() {
         *entry = get_knight_attacks(Square::from(sq)).0;
     }
-    KNIGHT_ATTACKS.set(knight_attacks_table).unwrap();
+    table
+});
 
-    let mut king_attacks_table = [0u64; SQUARES];
-    for (sq, entry) in king_attacks_table.iter_mut().enumerate() {
+static KING_ATTACKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
+    let mut table = [0u64; SQUARES];
+    for (sq, entry) in table.iter_mut().enumerate() {
         *entry = get_king_attacks(Square::from(sq)).0;
     }
-    KING_ATTACKS.set(king_attacks_table).unwrap();
+    table
+});
 
-    let mut bishop_attacks_table: Vec<[u64; MAX_BISHOP_MASK]> = vec![[0u64; MAX_BISHOP_MASK]; SQUARES];
+static BISHOP_ATTACKS: LazyLock<Vec<[u64; MAX_BISHOP_MASK]>> = LazyLock::new(|| {
+    let mut table: Vec<[u64; MAX_BISHOP_MASK]> = vec![[0u64; MAX_BISHOP_MASK]; SQUARES];
+    let bishop_mask_bits = &*BISHOP_MASK_BITS;
+
     for sq in 0..SQUARES {
         let mask = get_bishop_mask(Square::from(sq));
-        let bits = BISHOP_MASK_BITS.get().unwrap()[sq];
+        let bits = bishop_mask_bits[sq];
         let index_count = 1usize << bits;
 
         for index in 0..index_count {
@@ -110,15 +85,19 @@ pub fn init() {
                 .0
                 .wrapping_mul(BISHOP_MAGICS[sq])
                 .wrapping_shr(64 - bits) as usize;
-            bishop_attacks_table[sq][magic_index] = get_bishop_attacks(Square::from(sq), occupancy).0;
+            table[sq][magic_index] = get_bishop_attacks(Square::from(sq), occupancy).0;
         }
     }
-    BISHOP_ATTACKS.set(bishop_attacks_table).unwrap();
+    table
+});
 
-    let mut rook_attacks_table: Vec<[u64; MAX_ROOK_MASK]> = vec![[0u64; MAX_ROOK_MASK]; SQUARES];
+static ROOK_ATTACKS: LazyLock<Vec<[u64; MAX_ROOK_MASK]>> = LazyLock::new(|| {
+    let mut table: Vec<[u64; MAX_ROOK_MASK]> = vec![[0u64; MAX_ROOK_MASK]; SQUARES];
+    let rook_mask_bits = &*ROOK_MASK_BITS;
+
     for sq in 0..SQUARES {
         let mask = get_rook_mask(Square::from(sq));
-        let bits = ROOK_MASK_BITS.get().unwrap()[sq];
+        let bits = rook_mask_bits[sq];
         let index_count = 1usize << bits;
 
         for index in 0..index_count {
@@ -127,11 +106,74 @@ pub fn init() {
                 .0
                 .wrapping_mul(ROOK_MAGICS[sq])
                 .wrapping_shr(64 - bits) as usize;
-            rook_attacks_table[sq][magic_index] = get_rook_attacks(Square::from(sq), occupancy).0;
+            table[sq][magic_index] = get_rook_attacks(Square::from(sq), occupancy).0;
         }
     }
-        ROOK_ATTACKS.set(rook_attacks_table).unwrap();
-    });
+    table
+});
+
+macro_rules! get_table {
+    ($lock:expr) => {{
+        #[cfg(debug_assertions)]
+        {
+            LazyLock::force(&$lock)
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            // SAFETY: `rudim::init()` must be called at program startup, which forces this LazyLock to initialize.
+            // get() will hence always return a value.
+            unsafe { LazyLock::get(&$lock).unwrap_unchecked() }
+        }
+    }};
+}
+
+#[inline(always)]
+fn bishop_mask_bits() -> &'static [u32; SQUARES] {
+    get_table!(BISHOP_MASK_BITS)
+}
+#[inline(always)]
+fn rook_mask_bits() -> &'static [u32; SQUARES] {
+    get_table!(ROOK_MASK_BITS)
+}
+#[inline(always)]
+fn bishop_masks() -> &'static [u64; SQUARES] {
+    get_table!(BISHOP_MASKS)
+}
+#[inline(always)]
+fn rook_masks() -> &'static [u64; SQUARES] {
+    get_table!(ROOK_MASKS)
+}
+#[inline(always)]
+pub fn pawn_attacks() -> &'static [[u64; SQUARES]; 2] {
+    get_table!(PAWN_ATTACKS)
+}
+#[inline(always)]
+pub fn knight_attacks() -> &'static [u64; SQUARES] {
+    get_table!(KNIGHT_ATTACKS)
+}
+#[inline(always)]
+pub fn king_attacks() -> &'static [u64; SQUARES] {
+    get_table!(KING_ATTACKS)
+}
+#[inline(always)]
+fn bishop_attacks() -> &'static Vec<[u64; MAX_BISHOP_MASK]> {
+    get_table!(BISHOP_ATTACKS)
+}
+#[inline(always)]
+fn rook_attacks() -> &'static Vec<[u64; MAX_ROOK_MASK]> {
+    get_table!(ROOK_ATTACKS)
+}
+
+pub fn init() {
+    let _ = &*BISHOP_MASK_BITS;
+    let _ = &*ROOK_MASK_BITS;
+    let _ = &*BISHOP_MASKS;
+    let _ = &*ROOK_MASKS;
+    let _ = &*PAWN_ATTACKS;
+    let _ = &*KNIGHT_ATTACKS;
+    let _ = &*KING_ATTACKS;
+    let _ = &*BISHOP_ATTACKS;
+    let _ = &*ROOK_ATTACKS;
 }
 
 #[inline]
@@ -171,7 +213,6 @@ mod tests {
 
     #[test]
     fn pawn_table_matches_computed_for_all_squares() {
-        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
@@ -189,7 +230,6 @@ mod tests {
 
     #[test]
     fn knight_table_matches_computed_for_all_squares() {
-        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
@@ -202,7 +242,6 @@ mod tests {
 
     #[test]
     fn king_table_matches_computed_for_all_squares() {
-        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
@@ -215,7 +254,6 @@ mod tests {
 
     #[test]
     fn bishop_table_lookup_matches_computed_no_blockers() {
-        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -227,7 +265,6 @@ mod tests {
 
     #[test]
     fn bishop_table_lookup_matches_computed_with_blocker() {
-        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::D4 as usize);
         let square = Square::E5;
@@ -238,7 +275,6 @@ mod tests {
 
     #[test]
     fn rook_table_lookup_matches_computed_no_blockers() {
-        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -250,7 +286,6 @@ mod tests {
 
     #[test]
     fn rook_table_lookup_matches_computed_with_blockers() {
-        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::E3 as usize);
         occupancy.set_bit(Square::F5 as usize);
@@ -262,7 +297,6 @@ mod tests {
 
     #[test]
     fn queen_table_lookup_matches_computed_no_blockers() {
-        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -274,7 +308,6 @@ mod tests {
 
     #[test]
     fn queen_table_lookup_matches_computed_with_blockers() {
-        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::D4 as usize);
         occupancy.set_bit(Square::E3 as usize);

--- a/src/bitboard/lookups.rs
+++ b/src/bitboard/lookups.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::sync::{Once, OnceLock};
 
 use crate::bitboard::Bitboard;
 use crate::bitboard::attacks::{
@@ -11,72 +11,97 @@ use crate::common::constants::{MAX_BISHOP_MASK, MAX_ROOK_MASK, SQUARES};
 use crate::common::side::Side;
 use crate::common::square::Square;
 
-static BISHOP_MASK_BITS: LazyLock<[u32; SQUARES]> = LazyLock::new(|| {
-    let mut bits = [0u32; SQUARES];
-    for (sq, entry) in bits.iter_mut().enumerate() {
+static BISHOP_MASK_BITS: OnceLock<[u32; SQUARES]> = OnceLock::new();
+static ROOK_MASK_BITS: OnceLock<[u32; SQUARES]> = OnceLock::new();
+static BISHOP_MASKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
+static ROOK_MASKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
+static PAWN_ATTACKS: OnceLock<[[u64; SQUARES]; 2]> = OnceLock::new();
+static KNIGHT_ATTACKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
+static KING_ATTACKS: OnceLock<[u64; SQUARES]> = OnceLock::new();
+static BISHOP_ATTACKS: OnceLock<Vec<[u64; MAX_BISHOP_MASK]>> = OnceLock::new();
+static ROOK_ATTACKS: OnceLock<Vec<[u64; MAX_ROOK_MASK]>> = OnceLock::new();
+
+macro_rules! get_table {
+    ($lock:expr) => {
+        {
+            #[cfg(debug_assertions)]
+            {
+                if $lock.get().is_none() {
+                    crate::init();
+                }
+                $lock.get().unwrap()
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                unsafe { $lock.get().unwrap_unchecked() }
+            }
+        }
+    };
+}
+
+#[inline(always)] fn bishop_mask_bits() -> &'static [u32; SQUARES] { get_table!(BISHOP_MASK_BITS) }
+#[inline(always)] fn rook_mask_bits() -> &'static [u32; SQUARES] { get_table!(ROOK_MASK_BITS) }
+#[inline(always)] fn bishop_masks() -> &'static [u64; SQUARES] { get_table!(BISHOP_MASKS) }
+#[inline(always)] fn rook_masks() -> &'static [u64; SQUARES] { get_table!(ROOK_MASKS) }
+#[inline(always)] pub fn pawn_attacks() -> &'static [[u64; SQUARES]; 2] { get_table!(PAWN_ATTACKS) }
+#[inline(always)] pub fn knight_attacks() -> &'static [u64; SQUARES] { get_table!(KNIGHT_ATTACKS) }
+#[inline(always)] pub fn king_attacks() -> &'static [u64; SQUARES] { get_table!(KING_ATTACKS) }
+#[inline(always)] fn bishop_attacks() -> &'static Vec<[u64; MAX_BISHOP_MASK]> { get_table!(BISHOP_ATTACKS) }
+#[inline(always)] fn rook_attacks() -> &'static Vec<[u64; MAX_ROOK_MASK]> { get_table!(ROOK_ATTACKS) }
+
+static INIT_ONCE: Once = Once::new();
+
+pub fn init() {
+    INIT_ONCE.call_once(|| {
+        let mut bishop_mask_bits_table = [0u32; SQUARES];
+    for (sq, entry) in bishop_mask_bits_table.iter_mut().enumerate() {
         *entry = get_bishop_mask(Square::from(sq)).0.count_ones();
     }
-    bits
-});
+    BISHOP_MASK_BITS.set(bishop_mask_bits_table).unwrap();
 
-static ROOK_MASK_BITS: LazyLock<[u32; SQUARES]> = LazyLock::new(|| {
-    let mut bits = [0u32; SQUARES];
-    for (sq, entry) in bits.iter_mut().enumerate() {
+    let mut rook_mask_bits_table = [0u32; SQUARES];
+    for (sq, entry) in rook_mask_bits_table.iter_mut().enumerate() {
         *entry = get_rook_mask(Square::from(sq)).0.count_ones();
     }
-    bits
-});
+    ROOK_MASK_BITS.set(rook_mask_bits_table).unwrap();
 
-pub static BISHOP_MASKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
-    let mut masks = [0u64; SQUARES];
-    for (sq, entry) in masks.iter_mut().enumerate() {
+    let mut bishop_masks_table = [0u64; SQUARES];
+    for (sq, entry) in bishop_masks_table.iter_mut().enumerate() {
         *entry = get_bishop_mask(Square::from(sq)).0;
     }
-    masks
-});
+    BISHOP_MASKS.set(bishop_masks_table).unwrap();
 
-pub static ROOK_MASKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
-    let mut masks = [0u64; SQUARES];
-    for (sq, entry) in masks.iter_mut().enumerate() {
+    let mut rook_masks_table = [0u64; SQUARES];
+    for (sq, entry) in rook_masks_table.iter_mut().enumerate() {
         *entry = get_rook_mask(Square::from(sq)).0;
     }
-    masks
-});
+    ROOK_MASKS.set(rook_masks_table).unwrap();
 
-pub static PAWN_ATTACKS: LazyLock<[[u64; SQUARES]; 2]> = LazyLock::new(|| {
-    let mut table = [[0u64; SQUARES]; 2];
-    for (sq, entry) in table[Side::White as usize].iter_mut().enumerate() {
+    let mut pawn_attacks_table = [[0u64; SQUARES]; 2];
+    for (sq, entry) in pawn_attacks_table[Side::White as usize].iter_mut().enumerate() {
         *entry = get_pawn_attacks(Square::from(sq), Side::White).0;
     }
-    for (sq, entry) in table[Side::Black as usize].iter_mut().enumerate() {
+    for (sq, entry) in pawn_attacks_table[Side::Black as usize].iter_mut().enumerate() {
         *entry = get_pawn_attacks(Square::from(sq), Side::Black).0;
     }
-    table
-});
+    PAWN_ATTACKS.set(pawn_attacks_table).unwrap();
 
-pub static KNIGHT_ATTACKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
-    let mut table = [0u64; SQUARES];
-    for (sq, entry) in table.iter_mut().enumerate() {
+    let mut knight_attacks_table = [0u64; SQUARES];
+    for (sq, entry) in knight_attacks_table.iter_mut().enumerate() {
         *entry = get_knight_attacks(Square::from(sq)).0;
     }
-    table
-});
+    KNIGHT_ATTACKS.set(knight_attacks_table).unwrap();
 
-pub static KING_ATTACKS: LazyLock<[u64; SQUARES]> = LazyLock::new(|| {
-    let mut table = [0u64; SQUARES];
-    for (sq, entry) in table.iter_mut().enumerate() {
+    let mut king_attacks_table = [0u64; SQUARES];
+    for (sq, entry) in king_attacks_table.iter_mut().enumerate() {
         *entry = get_king_attacks(Square::from(sq)).0;
     }
-    table
-});
+    KING_ATTACKS.set(king_attacks_table).unwrap();
 
-pub static BISHOP_ATTACKS: LazyLock<Vec<[u64; MAX_BISHOP_MASK]>> = LazyLock::new(|| {
-    let mut table: Vec<[u64; MAX_BISHOP_MASK]> = vec![[0u64; MAX_BISHOP_MASK]; SQUARES];
-    let bishop_mask_bits = &*BISHOP_MASK_BITS;
-
+    let mut bishop_attacks_table: Vec<[u64; MAX_BISHOP_MASK]> = vec![[0u64; MAX_BISHOP_MASK]; SQUARES];
     for sq in 0..SQUARES {
         let mask = get_bishop_mask(Square::from(sq));
-        let bits = bishop_mask_bits[sq];
+        let bits = BISHOP_MASK_BITS.get().unwrap()[sq];
         let index_count = 1usize << bits;
 
         for index in 0..index_count {
@@ -85,19 +110,15 @@ pub static BISHOP_ATTACKS: LazyLock<Vec<[u64; MAX_BISHOP_MASK]>> = LazyLock::new
                 .0
                 .wrapping_mul(BISHOP_MAGICS[sq])
                 .wrapping_shr(64 - bits) as usize;
-            table[sq][magic_index] = get_bishop_attacks(Square::from(sq), occupancy).0;
+            bishop_attacks_table[sq][magic_index] = get_bishop_attacks(Square::from(sq), occupancy).0;
         }
     }
-    table
-});
+    BISHOP_ATTACKS.set(bishop_attacks_table).unwrap();
 
-pub static ROOK_ATTACKS: LazyLock<Vec<[u64; MAX_ROOK_MASK]>> = LazyLock::new(|| {
-    let mut table: Vec<[u64; MAX_ROOK_MASK]> = vec![[0u64; MAX_ROOK_MASK]; SQUARES];
-    let rook_mask_bits = &*ROOK_MASK_BITS;
-
+    let mut rook_attacks_table: Vec<[u64; MAX_ROOK_MASK]> = vec![[0u64; MAX_ROOK_MASK]; SQUARES];
     for sq in 0..SQUARES {
         let mask = get_rook_mask(Square::from(sq));
-        let bits = rook_mask_bits[sq];
+        let bits = ROOK_MASK_BITS.get().unwrap()[sq];
         let index_count = 1usize << bits;
 
         for index in 0..index_count {
@@ -106,44 +127,33 @@ pub static ROOK_ATTACKS: LazyLock<Vec<[u64; MAX_ROOK_MASK]>> = LazyLock::new(|| 
                 .0
                 .wrapping_mul(ROOK_MAGICS[sq])
                 .wrapping_shr(64 - bits) as usize;
-            table[sq][magic_index] = get_rook_attacks(Square::from(sq), occupancy).0;
+            rook_attacks_table[sq][magic_index] = get_rook_attacks(Square::from(sq), occupancy).0;
         }
     }
-    table
-});
-
-pub fn init() {
-    let _ = &*BISHOP_MASK_BITS;
-    let _ = &*ROOK_MASK_BITS;
-    let _ = &*BISHOP_MASKS;
-    let _ = &*ROOK_MASKS;
-    let _ = &*PAWN_ATTACKS;
-    let _ = &*KNIGHT_ATTACKS;
-    let _ = &*KING_ATTACKS;
-    let _ = &*BISHOP_ATTACKS;
-    let _ = &*ROOK_ATTACKS;
+        ROOK_ATTACKS.set(rook_attacks_table).unwrap();
+    });
 }
 
 #[inline]
 pub fn get_bishop_attacks_from_table(square: Square, occupancy: Bitboard) -> Bitboard {
     let sq = square as usize;
-    let bits = BISHOP_MASK_BITS[sq];
-    let mask = BISHOP_MASKS[sq];
+    let bits = bishop_mask_bits()[sq];
+    let mask = bishop_masks()[sq];
     let index = (occupancy.0 & mask)
         .wrapping_mul(BISHOP_MAGICS[sq])
         .wrapping_shr(64 - bits) as usize;
-    Bitboard(BISHOP_ATTACKS[sq][index])
+    Bitboard(bishop_attacks()[sq][index])
 }
 
 #[inline]
 pub fn get_rook_attacks_from_table(square: Square, occupancy: Bitboard) -> Bitboard {
     let sq = square as usize;
-    let bits = ROOK_MASK_BITS[sq];
-    let mask = ROOK_MASKS[sq];
+    let bits = rook_mask_bits()[sq];
+    let mask = rook_masks()[sq];
     let index = (occupancy.0 & mask)
         .wrapping_mul(ROOK_MAGICS[sq])
         .wrapping_shr(64 - bits) as usize;
-    Bitboard(ROOK_ATTACKS[sq][index])
+    Bitboard(rook_attacks()[sq][index])
 }
 
 #[inline]
@@ -161,16 +171,17 @@ mod tests {
 
     #[test]
     fn pawn_table_matches_computed_for_all_squares() {
+        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
                 get_pawn_attacks(square, Side::White).0,
-                PAWN_ATTACKS[Side::White as usize][sq],
+                pawn_attacks()[Side::White as usize][sq],
                 "White pawn mismatch at sq={sq}"
             );
             assert_eq!(
                 get_pawn_attacks(square, Side::Black).0,
-                PAWN_ATTACKS[Side::Black as usize][sq],
+                pawn_attacks()[Side::Black as usize][sq],
                 "Black pawn mismatch at sq={sq}"
             );
         }
@@ -178,11 +189,12 @@ mod tests {
 
     #[test]
     fn knight_table_matches_computed_for_all_squares() {
+        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
                 get_knight_attacks(square).0,
-                KNIGHT_ATTACKS[sq],
+                knight_attacks()[sq],
                 "Knight mismatch at sq={sq}"
             );
         }
@@ -190,11 +202,12 @@ mod tests {
 
     #[test]
     fn king_table_matches_computed_for_all_squares() {
+        init();
         for sq in 0..SQUARES {
             let square = Square::from(sq);
             assert_eq!(
                 get_king_attacks(square).0,
-                KING_ATTACKS[sq],
+                king_attacks()[sq],
                 "King mismatch at sq={sq}"
             );
         }
@@ -202,6 +215,7 @@ mod tests {
 
     #[test]
     fn bishop_table_lookup_matches_computed_no_blockers() {
+        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -213,6 +227,7 @@ mod tests {
 
     #[test]
     fn bishop_table_lookup_matches_computed_with_blocker() {
+        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::D4 as usize);
         let square = Square::E5;
@@ -223,6 +238,7 @@ mod tests {
 
     #[test]
     fn rook_table_lookup_matches_computed_no_blockers() {
+        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -234,6 +250,7 @@ mod tests {
 
     #[test]
     fn rook_table_lookup_matches_computed_with_blockers() {
+        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::E3 as usize);
         occupancy.set_bit(Square::F5 as usize);
@@ -245,6 +262,7 @@ mod tests {
 
     #[test]
     fn queen_table_lookup_matches_computed_no_blockers() {
+        init();
         let occupancy = Bitboard(0);
         for sq in 0..SQUARES {
             let square = Square::from(sq);
@@ -256,6 +274,7 @@ mod tests {
 
     #[test]
     fn queen_table_lookup_matches_computed_with_blockers() {
+        init();
         let mut occupancy = Bitboard(0);
         occupancy.set_bit(Square::D4 as usize);
         occupancy.set_bit(Square::E3 as usize);

--- a/src/board/make_move.rs
+++ b/src/board/make_move.rs
@@ -15,7 +15,7 @@ impl BoardState {
         let original_last_draw_killer = self.last_draw_killer;
 
         self.board_hash ^=
-            zobrist::ZOBRIST_TABLE[self.get_piece_on(m.source) as usize][m.source as usize];
+            zobrist::zobrist_table()[self.get_piece_on(m.source) as usize][m.source as usize];
         let moved_piece = self.remove_piece(m.source);
         if moved_piece == Piece::Pawn {
             self.last_draw_killer = self.move_count;
@@ -38,7 +38,7 @@ impl BoardState {
 
         self.add_piece(m.target, self.side_to_move, final_moved_piece);
         self.board_hash ^=
-            zobrist::ZOBRIST_TABLE[self.get_piece_on(m.target) as usize][m.target as usize];
+            zobrist::zobrist_table()[self.get_piece_on(m.target) as usize][m.target as usize];
 
         self.update_castling_rights(m);
         self.update_en_passant(m);
@@ -73,7 +73,7 @@ impl BoardState {
             m.target
         };
 
-        self.board_hash ^= zobrist::ZOBRIST_TABLE[self.get_piece_on(target_square) as usize]
+        self.board_hash ^= zobrist::zobrist_table()[self.get_piece_on(target_square) as usize]
             [target_square as usize];
         self.last_draw_killer = self.move_count;
 
@@ -115,8 +115,8 @@ impl BoardState {
         self.remove_piece(source);
         self.add_piece(target, side, Piece::Rook);
 
-        self.board_hash ^= zobrist::ZOBRIST_TABLE[rook_index as usize][source as usize];
-        self.board_hash ^= zobrist::ZOBRIST_TABLE[rook_index as usize][target as usize];
+        self.board_hash ^= zobrist::zobrist_table()[rook_index as usize][source as usize];
+        self.board_hash ^= zobrist::zobrist_table()[rook_index as usize][target as usize];
     }
 
     pub fn unmake_move(&mut self, m: Move) {

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -1,7 +1,7 @@
 use crate::bitboard::Bitboard;
 use crate::bitboard::lookups::{
-    KING_ATTACKS, KNIGHT_ATTACKS, PAWN_ATTACKS, get_bishop_attacks_from_table,
-    get_queen_attacks_from_table, get_rook_attacks_from_table,
+    get_bishop_attacks_from_table, get_queen_attacks_from_table, get_rook_attacks_from_table,
+    king_attacks, knight_attacks, pawn_attacks,
 };
 use crate::board::state::BoardState;
 use crate::common::castle::Castle;
@@ -85,7 +85,7 @@ impl BoardState {
             return;
         }
         let ep_bit = 1u64 << (self.en_passant_square as usize);
-        let attacks = Bitboard(PAWN_ATTACKS[self.side_to_move as usize][source] & ep_bit);
+        let attacks = Bitboard(pawn_attacks()[self.side_to_move as usize][source] & ep_bit);
         if attacks.0 > 0 {
             let target = attacks.get_lsb() as usize;
             self.add_pawn_move(source, target, true, false);
@@ -94,7 +94,7 @@ impl BoardState {
 
     fn generate_pawn_attacks(&mut self, source: usize) {
         let enemy_occ = self.occupancies[self.side_to_move.other() as usize];
-        let mut attacks = Bitboard(PAWN_ATTACKS[self.side_to_move as usize][source] & enemy_occ.0);
+        let mut attacks = Bitboard(pawn_attacks()[self.side_to_move as usize][source] & enemy_occ.0);
 
         while attacks.0 > 0 {
             let target = attacks.get_lsb() as usize;
@@ -123,7 +123,7 @@ impl BoardState {
         let mut bitboard = self.pieces[self.side_to_move as usize][Piece::Knight as usize];
         while bitboard.0 > 0 {
             let source = bitboard.get_lsb() as usize;
-            let attacks = Bitboard(KNIGHT_ATTACKS[source]);
+            let attacks = Bitboard(knight_attacks()[source]);
             self.add_attacks(source, attacks);
             bitboard.clear_bit(source);
         }
@@ -158,7 +158,7 @@ impl BoardState {
     fn generate_king_moves(&mut self) {
         let source =
             self.pieces[self.side_to_move as usize][Piece::King as usize].get_lsb() as usize;
-        let attacks = Bitboard(KING_ATTACKS[source]);
+        let attacks = Bitboard(king_attacks()[source]);
 
         self.add_attacks(source, attacks);
         self.generate_castle_moves();

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -94,7 +94,8 @@ impl BoardState {
 
     fn generate_pawn_attacks(&mut self, source: usize) {
         let enemy_occ = self.occupancies[self.side_to_move.other() as usize];
-        let mut attacks = Bitboard(pawn_attacks()[self.side_to_move as usize][source] & enemy_occ.0);
+        let mut attacks =
+            Bitboard(pawn_attacks()[self.side_to_move as usize][source] & enemy_occ.0);
 
         while attacks.0 > 0 {
             let target = attacks.get_lsb() as usize;

--- a/src/board/state.rs
+++ b/src/board/state.rs
@@ -1,7 +1,6 @@
 use crate::bitboard::Bitboard;
 use crate::bitboard::lookups::{
-    get_bishop_attacks_from_table,
-    get_rook_attacks_from_table, king_attacks, knight_attacks,
+    get_bishop_attacks_from_table, get_rook_attacks_from_table, king_attacks, knight_attacks,
     pawn_attacks,
 };
 use crate::board::history::History;
@@ -138,7 +137,8 @@ impl BoardState {
         {
             return true;
         }
-        if knight_attacks()[sq] & self.pieces[attacking_side as usize][Piece::Knight as usize].0 != 0
+        if knight_attacks()[sq] & self.pieces[attacking_side as usize][Piece::Knight as usize].0
+            != 0
         {
             return true;
         }

--- a/src/board/state.rs
+++ b/src/board/state.rs
@@ -1,7 +1,8 @@
 use crate::bitboard::Bitboard;
 use crate::bitboard::lookups::{
-    KING_ATTACKS, KNIGHT_ATTACKS, PAWN_ATTACKS, get_bishop_attacks_from_table,
-    get_rook_attacks_from_table,
+    get_bishop_attacks_from_table,
+    get_rook_attacks_from_table, king_attacks, knight_attacks,
+    pawn_attacks,
 };
 use crate::board::history::History;
 use crate::common::castle::Castle;
@@ -131,17 +132,17 @@ impl BoardState {
             return true;
         }
 
-        if PAWN_ATTACKS[defending_side as usize][sq]
+        if pawn_attacks()[defending_side as usize][sq]
             & self.pieces[attacking_side as usize][Piece::Pawn as usize].0
             != 0
         {
             return true;
         }
-        if KNIGHT_ATTACKS[sq] & self.pieces[attacking_side as usize][Piece::Knight as usize].0 != 0
+        if knight_attacks()[sq] & self.pieces[attacking_side as usize][Piece::Knight as usize].0 != 0
         {
             return true;
         }
-        if KING_ATTACKS[sq] & self.pieces[attacking_side as usize][Piece::King as usize].0 != 0 {
+        if king_attacks()[sq] & self.pieces[attacking_side as usize][Piece::King as usize].0 != 0 {
             return true;
         }
 

--- a/src/common/zobrist.rs
+++ b/src/common/zobrist.rs
@@ -2,42 +2,40 @@ use crate::board::state::BoardState;
 use crate::common::random;
 use crate::common::side::Side;
 use crate::common::square::Square;
-use std::sync::{Once, OnceLock};
+use std::sync::LazyLock;
 
-static ZOBRIST_TABLE_LOCK: OnceLock<[[u64; 64]; 14]> = OnceLock::new();
-static INIT_ONCE: Once = Once::new();
+static ZOBRIST_TABLE: LazyLock<[[u64; 64]; 14]> = LazyLock::new(|| {
+    let mut table = [[0u64; 64]; 14];
+    random::reset_seed();
+
+    // 12 piece types (6 for each color) and 64 squares, and extra - en passant, + edge cases below
+    // [13][0] == white to move
+    // [13][1] == black to move
+    // [13][2..18] == castling rights
+    for entry in table.iter_mut() {
+        for square in entry.iter_mut() {
+            *square = random::next_u64();
+        }
+    }
+
+    table
+});
 
 pub fn init() {
-    INIT_ONCE.call_once(|| {
-        let mut table = [[0u64; 64]; 14];
-        random::reset_seed();
-
-        // 12 piece types (6 for each color) and 64 squares, and extra - en passant, + edge cases below
-        // [13][0] == white to move
-        // [13][1] == black to move
-        // [13][2..18] == castling rights
-        for entry in table.iter_mut() {
-            for square in entry.iter_mut() {
-                *square = random::next_u64();
-            }
-        }
-
-        ZOBRIST_TABLE_LOCK.set(table).unwrap();
-    });
+    let _ = LazyLock::force(&ZOBRIST_TABLE);
 }
 
 #[inline(always)]
 pub fn zobrist_table() -> &'static [[u64; 64]; 14] {
     #[cfg(debug_assertions)]
     {
-        if ZOBRIST_TABLE_LOCK.get().is_none() {
-            crate::init();
-        }
-        ZOBRIST_TABLE_LOCK.get().unwrap()
+        LazyLock::force(&ZOBRIST_TABLE)
     }
     #[cfg(not(debug_assertions))]
     {
-        unsafe { ZOBRIST_TABLE_LOCK.get().unwrap_unchecked() }
+        // SAFETY: `rudim::init()` must be called at program startup, which forces this LazyLock to initialize.
+        // get() will hence always return a value.
+        unsafe { LazyLock::get(&ZOBRIST_TABLE).unwrap_unchecked() }
     }
 }
 
@@ -91,7 +89,6 @@ mod tests {
 
     #[test]
     fn test_starting_hash_is_deterministic() {
-        init();
         let board = BoardState::parse_fen(STARTING_FEN);
         let hash = get_board_hash(&board);
         assert_eq!(hash, 17316932686648747093);

--- a/src/common/zobrist.rs
+++ b/src/common/zobrist.rs
@@ -2,24 +2,44 @@ use crate::board::state::BoardState;
 use crate::common::random;
 use crate::common::side::Side;
 use crate::common::square::Square;
-use std::sync::LazyLock;
+use std::sync::{Once, OnceLock};
 
-pub static ZOBRIST_TABLE: LazyLock<[[u64; 64]; 14]> = LazyLock::new(|| {
-    let mut table = [[0u64; 64]; 14];
-    random::reset_seed();
+static ZOBRIST_TABLE_LOCK: OnceLock<[[u64; 64]; 14]> = OnceLock::new();
+static INIT_ONCE: Once = Once::new();
 
-    // 12 piece types (6 for each color) and 64 squares, and extra - en passant, + edge cases below
-    // [13][0] == white to move
-    // [13][1] == black to move
-    // [13][2..18] == castling rights
-    for entry in table.iter_mut() {
-        for square in entry.iter_mut() {
-            *square = random::next_u64();
+pub fn init() {
+    INIT_ONCE.call_once(|| {
+        let mut table = [[0u64; 64]; 14];
+        random::reset_seed();
+
+        // 12 piece types (6 for each color) and 64 squares, and extra - en passant, + edge cases below
+        // [13][0] == white to move
+        // [13][1] == black to move
+        // [13][2..18] == castling rights
+        for entry in table.iter_mut() {
+            for square in entry.iter_mut() {
+                *square = random::next_u64();
+            }
         }
-    }
 
-    table
-});
+        ZOBRIST_TABLE_LOCK.set(table).unwrap();
+    });
+}
+
+#[inline(always)]
+pub fn zobrist_table() -> &'static [[u64; 64]; 14] {
+    #[cfg(debug_assertions)]
+    {
+        if ZOBRIST_TABLE_LOCK.get().is_none() {
+            crate::init();
+        }
+        ZOBRIST_TABLE_LOCK.get().unwrap()
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        unsafe { ZOBRIST_TABLE_LOCK.get().unwrap_unchecked() }
+    }
+}
 
 pub fn get_board_hash(board_state: &BoardState) -> u64 {
     let mut current_hash = 0;
@@ -27,7 +47,7 @@ pub fn get_board_hash(board_state: &BoardState) -> u64 {
     for square in 0..64 {
         let piece = board_state.get_piece_on(Square::from(square));
         if piece != -1 {
-            current_hash ^= ZOBRIST_TABLE[piece as usize][square];
+            current_hash ^= zobrist_table()[piece as usize][square];
         }
     }
 
@@ -40,25 +60,25 @@ pub fn get_board_hash(board_state: &BoardState) -> u64 {
 
 pub fn hash_castling_rights(board_state: &BoardState, current_hash: u64) -> u64 {
     // Offset by 2 to avoid collision with side-to-move keys (which use [13][0] and [13][1])
-    current_hash ^ ZOBRIST_TABLE[13][2 + board_state.castle.bits() as usize]
+    current_hash ^ zobrist_table()[13][2 + board_state.castle.bits() as usize]
 }
 
 fn hash_side_to_move(board_state: &BoardState, current_hash: u64) -> u64 {
     current_hash
         ^ if board_state.side_to_move == Side::White {
-            ZOBRIST_TABLE[13][0]
+            zobrist_table()[13][0]
         } else {
-            ZOBRIST_TABLE[13][1]
+            zobrist_table()[13][1]
         }
 }
 
 pub fn flip_side_to_move_hashes(_board_state: &BoardState, current_hash: u64) -> u64 {
-    current_hash ^ ZOBRIST_TABLE[13][0] ^ ZOBRIST_TABLE[13][1]
+    current_hash ^ zobrist_table()[13][0] ^ zobrist_table()[13][1]
 }
 
 pub fn hash_en_passant(board_state: &BoardState, current_hash: u64) -> u64 {
     if board_state.en_passant_square != Square::NoSquare {
-        current_hash ^ ZOBRIST_TABLE[12][board_state.en_passant_square as usize]
+        current_hash ^ zobrist_table()[12][board_state.en_passant_square as usize]
     } else {
         current_hash
     }
@@ -71,6 +91,7 @@ mod tests {
 
     #[test]
     fn test_starting_hash_is_deterministic() {
+        init();
         let board = BoardState::parse_fen(STARTING_FEN);
         let hash = get_board_hash(&board);
         assert_eq!(hash, 17316932686648747093);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,8 @@ pub mod eval;
 pub mod perft;
 pub mod search;
 pub mod uci;
+
+pub fn init() {
+    bitboard::lookups::init();
+    common::zobrist::init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use rudim::bitboard::{lookups, magics};
+use rudim::bitboard::magics;
 use rudim::perft;
 use rudim::uci;
 
@@ -10,11 +10,11 @@ fn main() {
             magics::generate_all_magic_numbers();
         }
         Some("--perft") => {
-            lookups::init();
+            rudim::init();
             perft::run_cli();
         }
         _ => {
-            lookups::init();
+            rudim::init();
             uci::cli::run();
         }
     }


### PR DESCRIPTION
Profiled to notice a large amount of CPU time was being spent checking for init on the lock, attempting to avoid the initialization checks.