### PR TITLE
chore: remove check extensions

### DIFF
--- a/src/search/negamax.rs
+++ b/src/search/negamax.rs
@@ -54,11 +54,6 @@ fn search_internal(
     let is_pv_node = beta > 1 + alpha;
     let in_check = board_state.is_in_check(board_state.side_to_move);
 
-    let mut depth = depth;
-    if in_check {
-        depth += 1;
-    }
-
     if board_state.is_draw_in_search(ply as u16) {
         ctx.search_state.nodes += 1;
         return 0;

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -107,10 +107,10 @@ macro_rules! tactic_test_case {
     };
 }
 
-traversal_test_case!(traversal_starting, STARTING_FEN, 1066449, 35, 13);
-traversal_test_case!(traversal_endgame, ENDGAME_FEN, 5994255, 273, 17);
-traversal_test_case!(traversal_advanced, ADVANCED_MOVE_FEN, 23154310, 2837, 16);
-traversal_test_case!(traversal_kiwi_pete, KIWI_PETE_FEN, 1357194, -292, 12);
+traversal_test_case!(traversal_starting, STARTING_FEN, 613670, 37, 13);
+traversal_test_case!(traversal_endgame, ENDGAME_FEN, 294565, 317, 17);
+traversal_test_case!(traversal_advanced, ADVANCED_MOVE_FEN, 6002476, 2571, 16);
+traversal_test_case!(traversal_kiwi_pete, KIWI_PETE_FEN, 872205, -292, 12);
 
 tactic_test_case!(
     tactic_random_puzzle_position,


### PR DESCRIPTION
Looks like it's detrimental, maybe Singular Extensions later can help solve it.

STC
```
Elo   | 11.91 +- 5.46 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7704 W: 2688 L: 2424 D: 2592
Penta | [206, 846, 1590, 898, 312]
```

LTC
```
Elo   | 23.63 +- 7.51 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 3298 W: 1114 L: 890 D: 1294
Penta | [37, 337, 748, 419, 108]
```